### PR TITLE
Improve maxAge for Shields.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ACF PRO Installer
 
-[![Packagist](https://img.shields.io/packagist/v/philippbaschke/acf-pro-installer.svg?maxAge=2592000)](https://packagist.org/packages/philippbaschke/acf-pro-installer)
+[![Packagist](https://img.shields.io/packagist/v/philippbaschke/acf-pro-installer.svg?maxAge=3600)](https://packagist.org/packages/philippbaschke/acf-pro-installer)
 [![Packagist](https://img.shields.io/packagist/l/philippbaschke/acf-pro-installer.svg?maxAge=2592000)](https://github.com/PhilippBaschke/acf-pro-installer/blob/master/LICENSE)
-[![Travis](https://img.shields.io/travis/PhilippBaschke/acf-pro-installer.svg?maxAge=2592000)](https://travis-ci.org/PhilippBaschke/acf-pro-installer)
-[![Coveralls](https://img.shields.io/coveralls/PhilippBaschke/acf-pro-installer.svg?maxAge=2592000)](https://coveralls.io/github/PhilippBaschke/acf-pro-installer)
+[![Travis](https://img.shields.io/travis/PhilippBaschke/acf-pro-installer.svg?maxAge=3600)](https://travis-ci.org/PhilippBaschke/acf-pro-installer)
+[![Coveralls](https://img.shields.io/coveralls/PhilippBaschke/acf-pro-installer.svg?maxAge=3600)](https://coveralls.io/github/PhilippBaschke/acf-pro-installer)
 
 A composer plugin that makes installing [ACF PRO] with [composer] easier. 
 


### PR DESCRIPTION
The packagist version badge would show an outdated version number. 
The maxAge of 3600 matches the caching time of packagist.

Changed the maxAge of Travis and Coveralls as well because they 
might change as well.

The license badge can stay at the high max Age because it is not going to 
change very often.