### PR TITLE
Updated README.md with suggestion for alternate repository type

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ It reads your :key: ACF PRO key from the **environment** or a **.env file**.
 ```
 Replace `"version": "*.*.*(.*)"` with your desired version.
 
+Replace `"type": "wordpress-plugin"` with `"type": "library"` if you would like to have ACF PRO installed in the `./vendor` directory instead of `./wp-content/plugins/`. This may be desireable if for example, you are including ACF PRO in a Wordpress theme.
+
 **2. Make your ACF PRO key available**
 
 Set the environment variable **`ACF_PRO_KEY`** to your [ACF PRO key][acf-account].

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It reads your :key: ACF PRO key from the **environment** or a **.env file**.
 ```
 Replace `"version": "*.*.*(.*)"` with your desired version.
 
-Replace `"type": "wordpress-plugin"` with `"type": "library"` if you would like to have ACF PRO installed in the `./vendor` directory instead of `./wp-content/plugins/`. This may be desireable if for example, you are including ACF PRO in a Wordpress theme.
+Replace `"type": "wordpress-plugin"` with `"type": "library"` if you would like to have ACF PRO installed in the `./vendor` directory instead of `./wp-content/plugins`. This may be desireable if for example, you are including ACF PRO in a WordPress theme.
 
 **2. Make your ACF PRO key available**
 


### PR DESCRIPTION
This is a very useful composer plugin for including ACF PRO in your Wordpress-based project. If implemented as the README currently suggests, it installs ACF PRO in the ./wp-content/plugins/ folder in your project. This may not always be desirable. I don't use composer all the time, and it took me a bit to figure out how to prevent this behavior. I thought it might benefit others to provide this additional info in the README.