### PR TITLE
Doesn't work with plugin Hirak/prestissimo

### DIFF
--- a/src/ACFProInstaller/Plugin.php
+++ b/src/ACFProInstaller/Plugin.php
@@ -90,7 +90,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         return [
             PackageEvents::PRE_PACKAGE_INSTALL => 'addVersion',
             PackageEvents::PRE_PACKAGE_UPDATE => 'addVersion',
-            PluginEvents::PRE_FILE_DOWNLOAD => 'addKey'
+            PluginEvents::PRE_FILE_DOWNLOAD => [ 'addKey', -1 ],
         ];
     }
 

--- a/tests/ACFProInstaller/PluginTest.php
+++ b/tests/ACFProInstaller/PluginTest.php
@@ -75,7 +75,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase
         $subscribedEvents = Plugin::getSubscribedEvents();
         $this->assertEquals(
             $subscribedEvents[PluginEvents::PRE_FILE_DOWNLOAD],
-            'addKey'
+            [ 'addKey', -1 ]
         );
     }
 


### PR DESCRIPTION
When using this plugin in conjunction with hirak/prestissimo, the download of acf-pro fails because the custom RemoteFileSystem is overwritten. In order to get it working, we should ensure that this plugins runs *after* hirak/prestissimo.
As both are running with a priority set to 0, setting this one to -1 resolves the issue.