### PR TITLE
Support for composer.json extra attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Alternatively you can add an entry to your **`.env`** file:
 ACF_PRO_KEY=Your-Key-Here
 ```
 
+Or you can add an entry to your **`composer.json`** file:
+
+```json
+{
+  "extra": {
+    "advanced-custom-fields-pro-key": "Your-Key-Here"
+  }
+}
+```
+
 **3. Require ACF PRO**
 
 ```sh

--- a/src/ACFProInstaller/Exceptions/MissingKeyException.php
+++ b/src/ACFProInstaller/Exceptions/MissingKeyException.php
@@ -1,21 +1,8 @@
 <?php namespace PhilippBaschke\ACFProInstaller\Exceptions;
 
 /**
- * Exception thrown if the ACF PRO key is not available in the environment
+ * Exception thrown if the ACF PRO key is not available.
  */
-class MissingKeyException extends \Exception
+abstract class MissingKeyException extends \Exception
 {
-    public function __construct(
-        $message = '',
-        $code = 0,
-        \Exception $previous = null
-    ) {
-        parent::__construct(
-            'Could not find a key for ACF PRO. ' .
-            'Please make it available via the environment variable ' .
-            $message,
-            $code,
-            $previous
-        );
-    }
 }

--- a/src/ACFProInstaller/Exceptions/MissingKeyFromComposerExtraException.php
+++ b/src/ACFProInstaller/Exceptions/MissingKeyFromComposerExtraException.php
@@ -1,0 +1,21 @@
+<?php namespace PhilippBaschke\ACFProInstaller\Exceptions;
+
+/**
+ * Exception thrown if the ACF PRO key is not available in the composer extra section.
+ */
+class MissingKeyFromComposerExtraException extends MissingKeyException
+{
+    public function __construct(
+        $message = '',
+        $code = 0,
+        \Exception $previous = null
+    ) {
+        parent::__construct(
+            'Could not find a key for ACF PRO. ' .
+            'Please make it available via the composer extra section\'s ' .
+            $message,
+            $code,
+            $previous
+        );
+    }
+}

--- a/src/ACFProInstaller/Exceptions/MissingKeyFromEnvironmentException.php
+++ b/src/ACFProInstaller/Exceptions/MissingKeyFromEnvironmentException.php
@@ -1,0 +1,21 @@
+<?php namespace PhilippBaschke\ACFProInstaller\Exceptions;
+
+/**
+ * Exception thrown if the ACF PRO key is not available in the environment.
+ */
+class MissingKeyFromEnvironmentException extends MissingKeyException
+{
+    public function __construct(
+        $message = '',
+        $code = 0,
+        \Exception $previous = null
+    ) {
+        parent::__construct(
+            'Could not find a key for ACF PRO. ' .
+            'Please make it available via the environment variable ' .
+            $message,
+            $code,
+            $previous
+        );
+    }
+}

--- a/tests/ACFProInstaller/Exceptions/MissingKeyFromComposerExtraExceptionTest.php
+++ b/tests/ACFProInstaller/Exceptions/MissingKeyFromComposerExtraExceptionTest.php
@@ -1,0 +1,18 @@
+<?php namespace PhilippBaschke\ACFProInstaller\Test\Exceptions;
+
+use PhilippBaschke\ACFProInstaller\Exceptions\MissingKeyFromComposerExtraException;
+
+class MissingKeyFromComposerExtraExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testMessage()
+    {
+        $message = 'FIELD';
+        $e = new MissingKeyFromComposerExtraException($message);
+        $this->assertEquals(
+            'Could not find a key for ACF PRO. ' .
+            'Please make it available via the composer extra section\'s ' .
+            $message,
+            $e->getMessage()
+        );
+    }
+}

--- a/tests/ACFProInstaller/Exceptions/MissingKeyFromEnvironmentExceptionTest.php
+++ b/tests/ACFProInstaller/Exceptions/MissingKeyFromEnvironmentExceptionTest.php
@@ -1,13 +1,13 @@
 <?php namespace PhilippBaschke\ACFProInstaller\Test\Exceptions;
 
-use PhilippBaschke\ACFProInstaller\Exceptions\MissingKeyException;
+use PhilippBaschke\ACFProInstaller\Exceptions\MissingKeyFromEnvironmentException;
 
-class MissingKeyExceptionTest extends \PHPUnit_Framework_TestCase
+class MissingKeyFromEnvironmentExceptionTest extends \PHPUnit_Framework_TestCase
 {
     public function testMessage()
     {
         $message = 'FIELD';
-        $e = new MissingKeyException($message);
+        $e = new MissingKeyFromEnvironmentException($message);
         $this->assertEquals(
             'Could not find a key for ACF PRO. ' .
             'Please make it available via the environment variable ' .


### PR DESCRIPTION
Added support for `composer.json`'s `extra` attribute (with key `advanced-custom-fields-pro-key`) as a fallback.