### PR TITLE
Adding -beta versioning for beta versions of the ACF package

### DIFF
--- a/src/ACFProInstaller/Plugin.php
+++ b/src/ACFProInstaller/Plugin.php
@@ -184,7 +184,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         // \A = start of string, \Z = end of string
         // See: http://stackoverflow.com/a/34994075
-        $major_minor_patch_optional = '/\A\d\.\d\.\d{1,2}(?:\.\d)?\Z/';
+        $major_minor_patch_optional = '/\A\d\.\d\.(\d{1,2}||\d{1,2}-beta\d)(?:\.\d)?\Z/';
 
         if (!preg_match($major_minor_patch_optional, $version)) {
             throw new \UnexpectedValueException(


### PR DESCRIPTION
As ACF is currently shipping out versions on the semantic beta suffixing such as `5.8.0-beta3` it seems necessary to also support those.

That is almost **mandatory** as at the moment being just those 5.8.x versions are bundled with Gutenberg blocks functions (ie. `acf_register_block`)