### PR TITLE
Upgrade to  version 3 of phpdonenv.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": ">=5.5",
     "composer-plugin-api": "^1.0",
-    "vlucas/phpdotenv": "^2.2"
+    "vlucas/phpdotenv": "^3.4"
   },
   "require-dev": {
     "composer/composer": "1.0.*",

--- a/src/ACFProInstaller/Plugin.php
+++ b/src/ACFProInstaller/Plugin.php
@@ -243,7 +243,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     protected function loadDotEnv()
     {
         if (file_exists(getcwd().DIRECTORY_SEPARATOR.'.env')) {
-            $dotenv = new Dotenv(getcwd());
+            $dotenv = Dotenv::create(getcwd());
             $dotenv->load();
         }
     }


### PR DESCRIPTION
Upgrade instructions at: https://github.com/vlucas/phpdotenv/blob/master/UPGRADING.md
Reason for the upgrade: Conflict with Bedrock which uses version 3 of the same, when used via composer: 
https://github.com/roots/bedrock/blob/master/composer.json#L35