### PR TITLE
Allow double digits in the minor version number when validating the version string

### DIFF
--- a/src/ACFProInstaller/Plugin.php
+++ b/src/ACFProInstaller/Plugin.php
@@ -184,7 +184,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         // \A = start of string, \Z = end of string
         // See: http://stackoverflow.com/a/34994075
-        $major_minor_patch_optional = '/\A\d\.\d\.\d{1,2}(?:\.\d)?\Z/';
+        $major_minor_patch_optional = '/\A\d\.\d{1,2}\.\d{1,2}(?:\.\d)?\Z/';
 
         if (!preg_match($major_minor_patch_optional, $version)) {
             throw new \UnexpectedValueException(


### PR DESCRIPTION
This issue means folks can't update to ACF Pro 5.10.1

Resolves https://github.com/PhilippBaschke/acf-pro-installer/issues/47